### PR TITLE
Add freshness API route to fix dashboard loading

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ const inventoryRoutes = require('./routes/inventory');
 const brewingRoutes = require('./routes/brewing');
 const costRoutes = require('./routes/cost');
 const brewingLogRoutes = require('./routes/brewing-log');
+const freshnessRoutes = require('./routes/freshness');
 
 const app = express();
 const PORT = process.env.PORT || 5001;
@@ -107,6 +108,7 @@ app.use('/api/inventory', inventoryRoutes);
 app.use('/api/brewing', brewingRoutes);
 app.use('/api/cost', costRoutes);
 app.use('/api/brewing-log', brewingLogRoutes);
+app.use('/api/freshness', freshnessRoutes);
 
 // Health check endpoint
 app.get('/api/health', (req, res) => {

--- a/server/routes/freshness.js
+++ b/server/routes/freshness.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../db');
+
+// Get freshness alerts for coffee beans
+router.get('/alerts', async (req, res) => {
+  try {
+    // For now, return empty array to prevent dashboard errors
+    // TODO: Implement proper freshness logic
+    res.json([]);
+  } catch (error) {
+    console.error('Error fetching freshness alerts:', error);
+    res.status(500).json({ error: 'Failed to fetch freshness alerts' });
+  }
+});
+
+module.exports = router; 


### PR DESCRIPTION
This PR adds a freshness API route to prevent dashboard loading errors. The route returns an empty array for now but prevents the dashboard from failing when trying to fetch freshness alerts.